### PR TITLE
use the psycopg2 rpm on RedHat systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,7 +103,7 @@
   when:
     - postgres_databases is defined or
       postgres_users is defined
-    - ansible_os_family != "Debian"
+    - ansible_os_family == "Alpine"
 
 - name: Flush handlers again
   ansible.builtin.meta: flush_handlers

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,7 +15,8 @@ _postgres_packages:
     - python3-psycopg2
   RedHat:
     - postgresql-server
-    - postgresql-devel
+    - postgresql # client
+    - python3-psycopg2
 postgres_packages: "{{ _postgres_packages[ansible_os_family] | default(_postgres_packages['default']) }}"
 
 # The default postgres version for each distribution differs and is used in the directory structure.


### PR DESCRIPTION
---
name: redhat_psycopg2
about: Use the psycopg2 package on the Red Hat family of distributions

---

Running this on Fedora server, I noticed it downloads the psycopg2 pip instead of using the supplied rpm. The package is in the AppStream repo for RHEL and clones so we should be able to use the package on the entire RedHat family.

**Testing**
Tested on Fedora Server 41Beta
